### PR TITLE
Replace duplicate function

### DIFF
--- a/dynaboard.yml
+++ b/dynaboard.yml
@@ -133,24 +133,6 @@ nodes:
           renderAs: default
           dateTimeFormat: MMMM dd, y 'at' ttt
       autoselectFirstRow: true
-  1412782e-e410-44ea-8a5e-25d4a283ac2b:
-    type: FUNCTION
-    name: getSQLDataRows
-    properties:
-      action:
-        query: |-
-          SELECT
-            *
-          FROM
-            users
-          WHERE
-            {{ !sqlSearchInput.value }}
-            OR name ILIKE {{ "%" + sqlSearchInput.value + "%" }}
-            OR email ILIKE {{ "%" + sqlSearchInput.value + "%" }}
-        targetNode:
-          ref: d4d4a1a6-d921-4a4c-947e-a40cfeb1e4d8
-        actionType: PERFORM_QUERY
-      callingSemantics: REACTIVE
   1aeeba95-af76-495c-8fa9-fb43bfd7da23:
     type: DATA_TABLE
     name: dataTable
@@ -450,7 +432,7 @@ nodes:
           orderKey: a0V
         - nodeID: 4727b12c-7069-4d5a-b464-96c7933157c0
           orderKey: a4
-        - nodeID: 1412782e-e410-44ea-8a5e-25d4a283ac2b
+        - nodeID: e9c5e47d-c8ce-409b-ae23-10b71516380b
           orderKey: a0
         - nodeID: 855f92f6-17f0-435a-9f81-ac3a7da5de95
           orderKey: a5


### PR DESCRIPTION
replaces duplicate function

we had 2 functions with the same name and body. This one is also bound to the "onRefresh" handler of the table, so I preferred it over the duplicate with no references